### PR TITLE
qcom: Import removed board flags from hardware/qcom-caf/common

### DIFF
--- a/BoardConfigQcom.mk
+++ b/BoardConfigQcom.mk
@@ -274,6 +274,13 @@ endif
 # Tell HALs that we're compiling an AOSP build with an in-line kernel
 TARGET_COMPILE_WITH_MSM_KERNEL := true
 
+ifneq ($(filter msm8937 msm8953 msm8996,$(TARGET_BOARD_PLATFORM)),)
+    TARGET_USES_QCOM_MM_AUDIO := true
+    MSM_VIDC_TARGET_LIST := msm8937 msm8953 msm8996
+    TARGET_USES_MEDIA_EXTENSIONS := true
+    TARGET_USES_COLOR_METADATA := true
+endif
+
 # Enable DRM PP driver on UM platforms that support it
 ifneq ($(filter $(UM_4_9_FAMILY) $(UM_4_14_FAMILY) $(UM_4_19_FAMILY) $(UM_5_4_FAMILY) $(UM_5_10_FAMILY) $(UM_5_15_FAMILY) $(UM_6_1_FAMILY) $(UM_6_6_FAMILY),$(TARGET_BOARD_PLATFORM)),)
     SOONG_CONFIG_qtidisplay_drmpp := true


### PR DESCRIPTION
this is a continuation of these two commits :https://github.com/AfterlifeOS/hardware_qcom-caf_common/commit/cd562c511813e12a60f5c8e5a2d755647214035c and https://github.com/AfterlifeOS/hardware_qcom-caf_common/commit/dacf91affba45f57af875d6d7048c486dfbe447c

These two commits break our tree of HALs that haven't migrated to Android Blueprint, namely MSM8937/8953/8996 HALs. Instead of removing them, it's better to add them like this commit. Revert this commit if our HALs have migrated to Blueprint :v